### PR TITLE
Updates podspec for linting

### DIFF
--- a/OktaJWT.podspec
+++ b/OktaJWT.podspec
@@ -15,5 +15,5 @@ Library to sign and validate JSON Web Tokens.
 
   s.ios.deployment_target = '8.0'
 
-  s.source_files = 'OktaJWT/**/*'
+  s.source_files = 'OktaJWT/**/*.{h,m,swift}'
 end


### PR DESCRIPTION
When running `pod lib lint`, errors were thrown trying to parse the embedded `LICENSE` file. Instead, we only look at files ending with `.h`, `.m`, and `.swift`.