### PR TITLE
Remove param with the default value in OktaJWT core implementation

### DIFF
--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -23,7 +23,7 @@ public class OktaKeychain: NSObject {
     public class func loadKey(tag: String) {
         if let storedKey = self.get("com.okta.jwt.keys") {
             self.remove(storedKey)
-            RSAKey.removeKeyWithTag(tag)
+            RSAKey.removeKeyWithTag(tag, keyStorageManager: nil)
         }
 
         self.set(key: "com.okta.jwt.keys", tag)

--- a/Sources/OktaJWT.swift
+++ b/Sources/OktaJWT.swift
@@ -249,7 +249,7 @@ public struct OktaJWTValidator {
                     var storedKeyString : String = ""
                     storedKeyString = String(data: storedKey, encoding: .utf8) ?? ""
                     try keyStorageManager.delete(with: storedKeyString)
-                    RSAKey.removeKeyWithTag(tag)
+                    RSAKey.removeKeyWithTag(tag, keyStorageManager: nil)
                 }
                 guard let objectData = tag.data(using: .utf8) else {
                     return

--- a/Sources/ThirdParty/JSONWebToken/SecKeyUtils.swift
+++ b/Sources/ThirdParty/JSONWebToken/SecKeyUtils.swift
@@ -55,7 +55,7 @@ public extension RSAKey {
         case notBase64Readable
         case badKeyFormat
     }
-    @discardableResult static func registerOrUpdateKey(_ keyData : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> RSAKey {
+    @discardableResult static func registerOrUpdateKey(_ keyData : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol?) throws -> RSAKey {
         let key : SecKey? = try {
             if let existingData = try getKeyData(tag, keyStorageManager: keyStorageManager) {
                 let newData = keyData.dataByStrippingX509Header()
@@ -73,11 +73,11 @@ public extension RSAKey {
             throw KeyUtilError.badKeyFormat
         }
     }
-    @discardableResult static func registerOrUpdateKey(modulus: Data, exponent : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> RSAKey {
+    @discardableResult static func registerOrUpdateKey(modulus: Data, exponent : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol?) throws -> RSAKey {
         let combinedData = Data(modulus: modulus, exponent: exponent)
         return try RSAKey.registerOrUpdateKey(combinedData, tag : tag, keyStorageManager: keyStorageManager)
     }
-    @discardableResult static func registerOrUpdatePublicPEMKey(_ keyData : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> RSAKey {
+    @discardableResult static func registerOrUpdatePublicPEMKey(_ keyData : Data, tag : String, keyStorageManager: PublicKeyStorageProtocol?) throws -> RSAKey {
         guard let stringValue = String(data: keyData, encoding: String.Encoding.utf8) else {
             throw KeyUtilError.notStringReadable
         }
@@ -107,17 +107,17 @@ public extension RSAKey {
         }
         return try RSAKey.registerOrUpdateKey(decodedKeyData, tag: tag, keyStorageManager: keyStorageManager)
     }
-    static func registeredKeyWithTag(_ tag : String, keyStorageManager: PublicKeyStorageProtocol? = nil) -> RSAKey? {
+    static func registeredKeyWithTag(_ tag : String, keyStorageManager: PublicKeyStorageProtocol?) -> RSAKey? {
         return ((try? getKey(tag, keyStorageManager: keyStorageManager)) ?? nil).map(RSAKey.init)
     }
-    static func removeKeyWithTag(_ tag : String, keyStorageManager: PublicKeyStorageProtocol? = nil) {
+    static func removeKeyWithTag(_ tag : String, keyStorageManager: PublicKeyStorageProtocol?) {
         do {
             try deleteKey(tag, keyStorageManager: keyStorageManager)
         } catch {}
     }
 }
 
-private func getKey(_ tag: String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> SecKey? {
+private func getKey(_ tag: String, keyStorageManager: PublicKeyStorageProtocol?) throws -> SecKey? {
     if (keyStorageManager != nil) {
         return getKeyForCustomStorageManager(tag, keyStorageManager: keyStorageManager!)
     } else {
@@ -160,7 +160,7 @@ private func getKeyForCustomStorageManager(_ tag: String, keyStorageManager: Pub
     }
 }
 
-private func getKeyData(_ tag: String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> Data? {
+private func getKeyData(_ tag: String, keyStorageManager: PublicKeyStorageProtocol?) throws -> Data? {
     if let keyStorageManager = keyStorageManager {
         do {
             return try keyStorageManager.data(with: tag)
@@ -184,7 +184,7 @@ private func getKeyData(_ tag: String, keyStorageManager: PublicKeyStorageProtoc
         }
     }
 }
-private func updateKey(_ tag: String, data: Data, keyStorageManager: PublicKeyStorageProtocol? = nil) throws {
+private func updateKey(_ tag: String, data: Data, keyStorageManager: PublicKeyStorageProtocol?) throws {
     if let keyStorageManager = keyStorageManager {
         do {
             try keyStorageManager.save(data: data, with: tag)
@@ -199,7 +199,7 @@ private func updateKey(_ tag: String, data: Data, keyStorageManager: PublicKeySt
     }
 }
 
-private func deleteKey(_ tag: String, keyStorageManager: PublicKeyStorageProtocol? = nil) throws {
+private func deleteKey(_ tag: String, keyStorageManager: PublicKeyStorageProtocol?) throws {
     if let keyStorageManager = keyStorageManager {
         do {
             try keyStorageManager.delete(with: tag)
@@ -226,7 +226,7 @@ private func matchQueryWithTag(_ tag : String) -> Dictionary<String, Any> {
     return query
 }
 
-private func addKey(_ tag: String, data: Data, keyStorageManager: PublicKeyStorageProtocol? = nil) throws -> SecKey? {
+private func addKey(_ tag: String, data: Data, keyStorageManager: PublicKeyStorageProtocol?) throws -> SecKey? {
     if let keyStorageManager = keyStorageManager {
         do {
             try keyStorageManager.save(data: data, with: tag)
@@ -248,7 +248,7 @@ private func addKey(_ tag: String, data: Data, keyStorageManager: PublicKeyStora
         var persistentRef: CFTypeRef?
         let status = SecItemAdd(publicAttributes as CFDictionary, &persistentRef)
         if status == noErr || status == errSecDuplicateItem {
-            return try getKey(tag)
+            return try getKey(tag, keyStorageManager: nil)
         }
         throw RSAKey.Error.securityError(status)
     }

--- a/Tests/MiscTests.swift
+++ b/Tests/MiscTests.swift
@@ -102,4 +102,32 @@ class MiscTests: XCTestCase {
             XCTAssertEqual(desc.localizedDescription, "Could not retrieve well-known metadata endpoint")
         }
     }
+
+    func testRegisterOrUpdateKey() {
+        #if os(iOS)
+        let mockStorage = MockKeyStorageManager()
+        let modulus = TestUtils.exampleJWK["n"]!
+        let exponent = TestUtils.exampleJWK["e"]!
+        let tag = "com.okta.jwt.0XoqZmZm5nBQtRxTwq5T29s0TzqtDj0zsr8lFHp98vg"
+
+        // Store key to default storage
+        var rsaKey = try? RSAKey.registerOrUpdateKey(modulus: Utils.base64URLDecode(modulus)!,
+                                                     exponent: Utils.base64URLDecode(exponent)!,
+                                                     tag: tag,
+                                                     keyStorageManager: nil)
+        XCTAssertNotNil(rsaKey)
+        var dataFromStorage = try? mockStorage.data(with: tag)
+        XCTAssertTrue(dataFromStorage?.isEmpty ?? false)
+
+        // Store key to custom storage
+        rsaKey = try? RSAKey.registerOrUpdateKey(modulus: Utils.base64URLDecode(modulus)!,
+                                                 exponent: Utils.base64URLDecode(exponent)!,
+                                                 tag: tag,
+                                                 keyStorageManager: mockStorage)
+        XCTAssertNotNil(rsaKey)
+        dataFromStorage = try? mockStorage.data(with: tag)
+        XCTAssertNotNil(dataFromStorage)
+        XCTAssertTrue(dataFromStorage!.count > 0)
+        #endif
+    }
 }

--- a/Tests/iOS/IdTokenTests.swift
+++ b/Tests/iOS/IdTokenTests.swift
@@ -27,7 +27,7 @@ class IdTokenTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        RSAKey.removeKeyWithTag("com.okta.jwt.0XoqZmZm5nBQtRxTwq5T29s0TzqtDj0zsr8lFHp98vg")
+        RSAKey.removeKeyWithTag("com.okta.jwt.0XoqZmZm5nBQtRxTwq5T29s0TzqtDj0zsr8lFHp98vg", keyStorageManager: nil)
     }
 
     func testInvalidIssuerForIdToken() {
@@ -81,7 +81,7 @@ class IdTokenTests: XCTestCase {
     }
 
     func testInvalidSignatureForIdTokenGivenJWK() {
-        RSAKey.removeKeyWithTag("com.okta.jwt.0XoqZmZm5nBQtRxTwq5T29s0TzqtDj0zsr8lFHp98vg")
+        RSAKey.removeKeyWithTag("com.okta.jwt.0XoqZmZm5nBQtRxTwq5T29s0TzqtDj0zsr8lFHp98vg", keyStorageManager: nil)
         let options = [
             "issuer": TestUtils.issuer,
             "audience": TestUtils.clientId

--- a/Tests/iOS/JWTTests.swift
+++ b/Tests/iOS/JWTTests.swift
@@ -31,7 +31,7 @@ class JWTTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        RSAKey.removeKeyWithTag("com.okta.jwt.QViC9OB_fQO3d5ktIegAWaR0SJHJqtFRZRSjqTI5m1M")
+        RSAKey.removeKeyWithTag("com.okta.jwt.QViC9OB_fQO3d5ktIegAWaR0SJHJqtFRZRSjqTI5m1M", keyStorageManager: nil)
     }
 
     func testInvalidJWT() {

--- a/Tests/macOS/JWTTestsMacOS.swift
+++ b/Tests/macOS/JWTTestsMacOS.swift
@@ -30,7 +30,7 @@ class JWTTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        RSAKey.removeKeyWithTag("com.okta.jwt.QViC9OB_fQO3d5ktIegAWaR0SJHJqtFRZRSjqTI5m1M")
+        RSAKey.removeKeyWithTag("com.okta.jwt.QViC9OB_fQO3d5ktIegAWaR0SJHJqtFRZRSjqTI5m1M", keyStorageManager: nil)
     }
 
     func testInvalidJWT() {


### PR DESCRIPTION
### Problem Analysis (Technical)
Easy to make a mistake in a code with `keyStorageManager=nil` as parameter approach. As a result we had a regression: https://github.com/okta/okta-ios-jwt/pull/46/files#diff-c8bbd0f720307a678da37173ed381dd9b78fc0250e8dee52b57f3407e8c0edcbR60

### Solution (Technical)
- Remove `keyStorageManager=nil` with default value param as it is error prone
- Add unit test for RSAKey.registerOrUpdateKey function to cover key store functionality