### PR TITLE
Offline error implementation

### DIFF
--- a/OktaJWT.xcodeproj/project.pbxproj
+++ b/OktaJWT.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		2FF91ADE23B5EC8D00CFC89C /* TestJWTs.plist in Resources */ = {isa = PBXBuildFile; fileRef = A126079922FA131B007AE25E /* TestJWTs.plist */; };
 		2FF91AE023B5EC9800CFC89C /* MiscTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126073F22FA0C4B007AE25E /* MiscTests.swift */; };
 		2FF91AE123B5EC9C00CFC89C /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126073D22FA0C4B007AE25E /* TestUtilities.swift */; };
+		925D9C4C27301CCA00380FA3 /* MockErroredURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D9C4B27301CCA00380FA3 /* MockErroredURLSession.swift */; };
+		925D9C4D27301CCA00380FA3 /* MockErroredURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D9C4B27301CCA00380FA3 /* MockErroredURLSession.swift */; };
 		92F22D6A262D8BD700EE57FD /* MockKeyStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F22D69262D8BD700EE57FD /* MockKeyStorageManager.swift */; };
 		92F22D6B262D8BD700EE57FD /* MockKeyStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F22D69262D8BD700EE57FD /* MockKeyStorageManager.swift */; };
 		92F22E93262DCC2100EE57FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F22E8A262DCC2100EE57FD /* ViewController.swift */; };
@@ -176,6 +178,7 @@
 		2FF91AA323B5E68400CFC89C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2FF91AAB23B5E8D300CFC89C /* OktaJWTLib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OktaJWTLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FF91AD223B5EC5600CFC89C /* OktaJWTTests_macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OktaJWTTests_macOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		925D9C4B27301CCA00380FA3 /* MockErroredURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockErroredURLSession.swift; sourceTree = "<group>"; };
 		92F22D2C262D728F00EE57FD /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		92F22D69262D8BD700EE57FD /* MockKeyStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKeyStorageManager.swift; sourceTree = "<group>"; };
 		92F22E8A262DCC2100EE57FD /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -193,7 +196,7 @@
 		A126073D22FA0C4B007AE25E /* TestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestUtilities.swift; path = Tests/TestUtilities.swift; sourceTree = SOURCE_ROOT; };
 		A126073E22FA0C4B007AE25E /* JWTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JWTTests.swift; path = Tests/iOS/JWTTests.swift; sourceTree = SOURCE_ROOT; };
 		A126073F22FA0C4B007AE25E /* MiscTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MiscTests.swift; path = Tests/MiscTests.swift; sourceTree = SOURCE_ROOT; };
-		A126074022FA0C4B007AE25E /* IdTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdTokenTests.swift; path = Tests/iOS/IdTokenTests.swift; sourceTree = SOURCE_ROOT; };
+		A126074022FA0C4B007AE25E /* IdTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdTokenTests.swift; path = Tests/IdTokenTests.swift; sourceTree = SOURCE_ROOT; };
 		A126074722FA0D34007AE25E /* JWTVerificationErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JWTVerificationErrors.swift; path = Sources/JWTVerificationErrors.swift; sourceTree = "<group>"; };
 		A126074822FA0D34007AE25E /* JWTVerifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JWTVerifier.swift; path = Sources/JWTVerifier.swift; sourceTree = "<group>"; };
 		A126074922FA0D34007AE25E /* RequestsAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestsAPI.swift; path = Sources/RequestsAPI.swift; sourceTree = "<group>"; };
@@ -346,7 +349,6 @@
 			children = (
 				92F22E89262DCC2100EE57FD /* OktaJWTTestSuite */,
 				2FF91A9F23B5E67E00CFC89C /* Info.plist */,
-				A126074022FA0C4B007AE25E /* IdTokenTests.swift */,
 				A126073E22FA0C4B007AE25E /* JWTTests.swift */,
 			);
 			path = iOS;
@@ -376,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				92F22D69262D8BD700EE57FD /* MockKeyStorageManager.swift */,
+				925D9C4B27301CCA00380FA3 /* MockErroredURLSession.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -449,6 +452,7 @@
 				92F22D71262D8BDF00EE57FD /* Mocks */,
 				92F22ED4262DD4C500EE57FD /* Resources */,
 				A126073F22FA0C4B007AE25E /* MiscTests.swift */,
+				A126074022FA0C4B007AE25E /* IdTokenTests.swift */,
 				CBC727FB25CCB96F0040BCC1 /* RequestsAPITests.swift */,
 				A126073D22FA0C4B007AE25E /* TestUtilities.swift */,
 			);
@@ -811,6 +815,7 @@
 				0332BB81250ABE01007F3C48 /* JWTTestsMacOS.swift in Sources */,
 				92F22D6B262D8BD700EE57FD /* MockKeyStorageManager.swift in Sources */,
 				2FF91AE023B5EC9800CFC89C /* MiscTests.swift in Sources */,
+				925D9C4D27301CCA00380FA3 /* MockErroredURLSession.swift in Sources */,
 				2FF91AE123B5EC9C00CFC89C /* TestUtilities.swift in Sources */,
 				92F22EA8262DCDEC00EE57FD /* IdTokenTests.swift in Sources */,
 			);
@@ -865,6 +870,7 @@
 				A126074422FA0C4B007AE25E /* MiscTests.swift in Sources */,
 				CBC727FC25CCB96F0040BCC1 /* RequestsAPITests.swift in Sources */,
 				2F16C59523C746EC009BBA3F /* IdTokenTests.swift in Sources */,
+				925D9C4C27301CCA00380FA3 /* MockErroredURLSession.swift in Sources */,
 				2FF91A9C23B5422400CFC89C /* TestUtilities.swift in Sources */,
 				92F22D6A262D8BD700EE57FD /* MockKeyStorageManager.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ do {
   // idToken issued in the future
 } catch OktaJWTVerificationError.invalidNonce {
   // Invalid nonce
+} catch OktaAPIError.noWellKnown {
+  // Could not retrieve well-known metadata
+} catch OktaAPIError.noJWKSEndpoint {
+  // Unable to capture jwks_uri from well-known
+} catch OktaAPIError.noKey {
+  // Unable to find JWK for Key ID
+} catch OktaAPIError.offline {
+  // Internet connection has not been established (device is offline)
 } catch let error {
   // Misc Error: {error}
 }

--- a/Sources/APIErrors.swift
+++ b/Sources/APIErrors.swift
@@ -16,6 +16,7 @@ public enum OktaAPIError: Error {
     case noWellKnown
     case noJWKSEndpoint
     case noKey
+    case offline
 }
 
 extension OktaAPIError: LocalizedError {
@@ -27,6 +28,8 @@ extension OktaAPIError: LocalizedError {
                 return NSLocalizedString("Unable to capture jwks_uri from well-known endpoint", comment: "")
             case .noKey:
                 return NSLocalizedString("Unable to find JWK for Key ID", comment: "")
+            case .offline:
+                return NSLocalizedString("Internet connection has not been established", comment: "")
             }
     }
 }

--- a/Sources/APIErrors.swift
+++ b/Sources/APIErrors.swift
@@ -29,7 +29,7 @@ extension OktaAPIError: LocalizedError {
             case .noKey:
                 return NSLocalizedString("Unable to find JWK for Key ID", comment: "")
             case .offline:
-                return NSLocalizedString("Internet connection has not been established", comment: "")
+                return NSLocalizedString("Internet connection could not been established", comment: "")
             }
     }
 }

--- a/Sources/JWTVerifier.swift
+++ b/Sources/JWTVerifier.swift
@@ -32,7 +32,7 @@ open class OktaJWTVerifier: NSObject {
         }
 
         // Try to get issuer from well-known endpoint first
-        if let wellKnownIssuer = RequestsAPI.getIssuerEndpoint(issuer: validIssuer!) {
+        if let wellKnownIssuer = try? RequestsAPI.getIssuerEndpoint(issuer: validIssuer!) {
             if dirtyIssuer! == wellKnownIssuer {
                 return true
             } else {

--- a/Sources/OktaJWT.swift
+++ b/Sources/OktaJWT.swift
@@ -221,8 +221,8 @@ public struct OktaJWTValidator {
                 NSURLErrorTimedOut:
                 throw OktaAPIError.offline
             case NSURLErrorCannotConnectToHost:
-                // Throws noWellKnown for backward-compatibility
-                throw OktaAPIError.noWellKnown
+                // This case should throw default error for backward-compatibility
+                fallthrough
             default:
                 // Throws noWellKnown for backward-compatibility
                 throw OktaAPIError.noWellKnown

--- a/Sources/OktaJWT.swift
+++ b/Sources/OktaJWT.swift
@@ -215,8 +215,14 @@ public struct OktaJWTValidator {
             let nsError = error as NSError
             
             switch nsError.code {
-            case NSURLErrorNotConnectedToInternet:
+            case
+                NSURLErrorNotConnectedToInternet,
+                NSURLErrorNetworkConnectionLost,
+                NSURLErrorTimedOut:
                 throw OktaAPIError.offline
+            case NSURLErrorCannotConnectToHost:
+                // Throws noWellKnown for backward-compatibility
+                throw OktaAPIError.noWellKnown
             default:
                 // Throws noWellKnown for backward-compatibility
                 throw OktaAPIError.noWellKnown

--- a/Sources/OktaJWT.swift
+++ b/Sources/OktaJWT.swift
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import Foundation
+
 let VERSION = "2.0.1"
 
 public struct OktaJWTValidator {
@@ -187,29 +189,39 @@ public struct OktaJWTValidator {
             return key
         }
 
-        var mJWK: [String: String]
-
-        if jwk == nil {
+        guard jwk == nil else {
+            return try self.createRSAKey(jwk!, kid: kid)
+        }
+        
+        do {
             // Set the class's wellKnown object to ensure we validate the JWT based on values pulled from the well-known endpoint
-            guard let wellKnown = RequestsAPI.getDiscoveryDocument(issuer: validatorOptions["iss"] as! String) else {
+            guard let wellKnown = try RequestsAPI.getDiscoveryDocument(issuer: validatorOptions["iss"] as! String) else {
                 throw OktaAPIError.noWellKnown
             }
-
+            
             // Call keys endpoint and find matching kid and create key
             guard let keysEndpoint = RequestsAPI.getKeysEndpoint(json: wellKnown) else {
                 throw OktaAPIError.noJWKSEndpoint
             }
-
-            guard let mKey = Utils.getKeyFromEndpoint(kid: kid, keysEndpoint) else {
+            
+            guard let mKey = try Utils.getKeyFromEndpoint(kid: kid, keysEndpoint) else {
                 throw OktaAPIError.noKey
             }
-
-            mJWK = mKey
-        } else {
-            mJWK = jwk!
+            
+            return try self.createRSAKey(mKey, kid: kid)
+        } catch where error is OktaAPIError {
+          throw error
+        } catch {
+            let nsError = error as NSError
+            
+            switch nsError.code {
+            case NSURLErrorNotConnectedToInternet:
+                throw OktaAPIError.offline
+            default:
+                // Throws noWellKnown for backward-compatibility
+                throw OktaAPIError.noWellKnown
+            }
         }
-
-        return try self.createRSAKey(mJWK, kid: kid)
     }
 
     /**

--- a/Sources/RequestsAPI.swift
+++ b/Sources/RequestsAPI.swift
@@ -14,6 +14,14 @@ import Foundation
 
 open class RequestsAPI: NSObject {
 
+    /// Internal. Only for tests reason.
+    private static var urlSession = URLSession.shared
+    
+    /// Internal. Only for tests reason.
+    static func setURLSession(_ urlSession: URLSession) {
+        self.urlSession = urlSession
+    }
+    
     /**
      Returns the OpenID Connect well-known metadata.
      - parameters:
@@ -103,7 +111,7 @@ open class RequestsAPI: NSObject {
         var responseError: Error?
         let semaphore = DispatchSemaphore(value: 0)
 
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = urlSession.dataTask(with: request) { data, response, error in
             responseData = data
             responseError = error
             

--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -100,12 +100,13 @@ open class Utils: NSObject {
      - returns:
      A JSON Web Key dictionary matching the JWTs kid
      */
-    open class func getKeyFromEndpoint(kid: String, _ keysEndpoint: String) -> [String: String]? {
-        let url = URL(string: keysEndpoint)
-        guard let keys = RequestsAPI.getJSON(url!)?["keys"] as? [Any] else {
-            return nil
-        }
-
+    open class func getKeyFromEndpoint(kid: String, _ keysEndpoint: String) throws -> [String: String]? {
+        guard let url = URL(string: keysEndpoint),
+              let keys = try RequestsAPI.getJSON(url)?["keys"] as? [Any] else
+              {
+                  return nil
+              }
+        
         return self.findKeyByKeyId(kid: kid, keys)
     }
 

--- a/Tests/MiscTests.swift
+++ b/Tests/MiscTests.swift
@@ -98,8 +98,9 @@ class MiscTests: XCTestCase {
 
         let validator = OktaJWTValidator(options)
         XCTAssertThrowsError(try validator.isValid(jwts["NoDiscoveryJWT"] as! String)) { error in
-            let desc = error as! OktaAPIError
-            XCTAssertEqual(desc.localizedDescription, "Could not retrieve well-known metadata endpoint")
+            let apiError = error as! OktaAPIError
+            XCTAssertEqual(apiError, .noWellKnown)
+            XCTAssertEqual(apiError.localizedDescription, "Could not retrieve well-known metadata endpoint")
         }
     }
 

--- a/Tests/Mocks/MockErroredURLSession.swift
+++ b/Tests/Mocks/MockErroredURLSession.swift
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+class MockErroredURLSession: URLSession {
+    
+    private let responseError: NSError
+    
+    init(responseError: NSError) {
+        self.responseError = responseError
+    }
+    
+    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        URLSession.shared.dataTask(with: request) { _, _, _ in
+            completionHandler(nil, nil, self.responseError)
+        }
+    }
+}

--- a/Tests/RequestsAPITests.swift
+++ b/Tests/RequestsAPITests.swift
@@ -23,8 +23,9 @@ class RequestsAPITests: XCTestCase {
     let incorrectJSONFileName = "sampleIncorrectJSON"
 
     func testRandomURL() throws {
-        let url:URL = URL(string: "hts://dummy.com")!
-        XCTAssertNil(RequestsAPI.getJSON(url))
+        let url = URL(string: "hts://dummy.com")!
+    
+        XCTAssertThrowsError(try RequestsAPI.getJSON(url))
     }
     
     func testCorrectJSONWithWorkingURL() throws {
@@ -38,7 +39,7 @@ class RequestsAPITests: XCTestCase {
         guard let url = bundle.url(forResource: correctJSONfileName, withExtension: "json") else {
             fatalError("Failed to locate \(correctJSONfileName) in bundle.")
         }
-        XCTAssertTrue(RequestsAPI.getJSON(url) != nil)
+        XCTAssertTrue(try! RequestsAPI.getJSON(url) != nil)
     }
 
     func testIncorrectJSONWithWorkingURL() throws {
@@ -51,6 +52,6 @@ class RequestsAPITests: XCTestCase {
         guard let url = bundle.url(forResource: incorrectJSONFileName, withExtension: "json") else {
             fatalError("Failed to locate \(incorrectJSONFileName) in bundle.")
         }
-        XCTAssertNil(RequestsAPI.getJSON(url))
+        XCTAssertNil(try! RequestsAPI.getJSON(url))
     }
 }

--- a/Tests/RequestsAPITests.swift
+++ b/Tests/RequestsAPITests.swift
@@ -25,7 +25,10 @@ class RequestsAPITests: XCTestCase {
     func testRandomURL() throws {
         let url = URL(string: "hts://dummy.com")!
     
-        XCTAssertThrowsError(try RequestsAPI.getJSON(url))
+        XCTAssertThrowsError(try RequestsAPI.getJSON(url)) { (error) in
+            let nsError = error as NSError
+            XCTAssertTrue(nsError.domain == NSURLErrorDomain)
+        }
     }
     
     func testCorrectJSONWithWorkingURL() throws {
@@ -37,8 +40,10 @@ class RequestsAPITests: XCTestCase {
         
         
         guard let url = bundle.url(forResource: correctJSONfileName, withExtension: "json") else {
-            fatalError("Failed to locate \(correctJSONfileName) in bundle.")
+            XCTFail("Failed to locate \(correctJSONfileName) in bundle.")
+            return
         }
+        
         XCTAssertTrue(try! RequestsAPI.getJSON(url) != nil)
     }
 
@@ -50,8 +55,10 @@ class RequestsAPITests: XCTestCase {
         #endif
         
         guard let url = bundle.url(forResource: incorrectJSONFileName, withExtension: "json") else {
-            fatalError("Failed to locate \(incorrectJSONFileName) in bundle.")
+            XCTFail("Failed to locate \(correctJSONfileName) in bundle.")
+            return
         }
+        
         XCTAssertNil(try! RequestsAPI.getJSON(url))
     }
 }


### PR DESCRIPTION
### Problem Analysis (Technical)
The iOS JWT library has a limitation where fetching the well-known configuration and keys while a device is offline results in a `noWellKnown` error being thrown. These checks also happen very early in the verification process, which means other validity checks aren't performed.

To improve the developer experience, and to account for offline scenarios, we should rearrange this behaviour so the network checks are performed last, and provide an additional error case to indicate network checks couldn't be performed. This can allow a developer to ignore network errors based on their use-case.

Issue ref.: [OKTA-439916](https://oktainc.atlassian.net/browse/OKTA-439916)

### Solution (Technical)

1. Introduce a new "offline" error to indicate that network verification checks could not be performed.
2. Relocate network checks to the end of JWT verification.
3. Return the new "offline" error when either the well-known configuration or keys could not be returned due to a network error only.
4. Add documentation to describe how and when to use this additional check.

### Tests

In progress. 
