### PR TITLE
Add validation options into OktaJWT library

### DIFF
--- a/Sources/RequestsAPI.swift
+++ b/Sources/RequestsAPI.swift
@@ -17,8 +17,12 @@ open class RequestsAPI: NSObject {
     /// Internal. Only for tests reason.
     private static var urlSession = URLSession.shared
     
-    /// Internal. Only for tests reason.
-    static func setURLSession(_ urlSession: URLSession) {
+    /**
+     Overrides default URLSession object
+     - parameters:
+         - urlSession: Custom URLSession object
+     */
+    public class func setURLSession(_ urlSession: URLSession) {
         self.urlSession = urlSession
     }
     


### PR DESCRIPTION
- Allow to enable/disable certain claims checks
- Allow to override URLSession in SDK(simplifies SSL pinning for apps)
- Move signature validation to the end of `isValid` function since it sends networks requests